### PR TITLE
Update libsvm_predict.c

### DIFF
--- a/libsvm/libsvm_predict.c
+++ b/libsvm/libsvm_predict.c
@@ -305,6 +305,8 @@ static int libsvm_predict(lua_State *L)
 						return 0;
 				}
 			}
+			
+			lua_pop(L,1);
 		}
 
 		model_ = Malloc(struct svm_model, 1);


### PR DESCRIPTION
We must pop the element at the top of lua stack, otherwise libsvm.predict(d,model,'-b 1') won't work.
