### PR TITLE
Fix `torch-svm` build in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,10 @@ ADD_SUBDIRECTORY(libsvm)
 
 SET(utilsrc init.c data.c util.c)
 ADD_LIBRARY(svmutil SHARED ${utilsrc})
-TARGET_LINK_LIBRARIES(svmutil luaT TH)
+TARGET_LINK_LIBRARIES(svmutil lua luaT TH)
 INSTALL(TARGETS svmutil LIBRARY DESTINATION ${Torch_INSTALL_LUA_CPATH_SUBDIR})
 
 SET(src)
 SET(luasrc init.lua data.lua)
 
-ADD_TORCH_PACKAGE(svm "${src}" "${luasrc}")
-ADD_TORCH_DOK(dok svm "Machine Learning" "Support Vector Machines" 3.99)
+ADD_TORCH_PACKAGE(svm "${src}" "${luasrc}" "SVM")


### PR DESCRIPTION
Summary:
Fixes compile errors when building.

Test Plan:

``` bash
∴ luarocks install svm-0.1-0.rockspec
Using svm-0.1-0.rockspec... switching to 'build' mode
Cloning into 'torch-svm'...
remote: Counting objects: 72, done.
remote: Compressing objects: 100% (65/65), done.
remote: Total 72 (delta 11), reused 49 (delta 5)
Receiving objects: 100% (72/72), 112.65 KiB | 0 bytes/s, done.
Resolving deltas: 100% (11/11), done.
Checking connectivity... done.
cmake -E make_directory build;
cd build;
cmake .. -DCMAKE_BUILD_TYPE=Release
-DCMAKE_PREFIX_PATH="/usr/local/bin/.."
-DCMAKE_INSTALL_PREFIX="/usr/local/lib/luarocks/rocks/svm/0.1-0";
make

-- The C compiler identification is Clang 5.1.0
-- The CXX compiler identification is Clang 5.1.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Found Torch7 in /usr/local
-- Configuring done
-- Generating done
-- Build files have been written to:
-- /tmp/luarocks_svm-0.1-0-33/torch-svm/build
Scanning dependencies of target svmutil
[  5%] Building C object CMakeFiles/svmutil.dir/init.c.o
[ 11%] Building C object CMakeFiles/svmutil.dir/data.c.o
[ 16%] Building C object CMakeFiles/svmutil.dir/util.c.o
Linking C shared library libsvmutil.dylib
[ 16%] Built target svmutil
Scanning dependencies of target liblinearblas
[ 22%] Building C object
-- liblinear/CMakeFiles/liblinearblas.dir/liblinear/blas/daxpy.c.o
[ 27%] Building C object
-- liblinear/CMakeFiles/liblinearblas.dir/liblinear/blas/ddot.c.o
[ 33%] Building C object
-- liblinear/CMakeFiles/liblinearblas.dir/liblinear/blas/dnrm2.c.o
[ 38%] Building C object
-- liblinear/CMakeFiles/liblinearblas.dir/liblinear/blas/dscal.c.o
Linking C static library libliblinearblas.a
[ 38%] Built target liblinearblas
Scanning dependencies of target liblinear
[ 44%] Building C object
-- liblinear/CMakeFiles/liblinear.dir/linear_model_torch.c.o
[ 50%] Building C object liblinear/CMakeFiles/liblinear.dir/init.c.o
[ 55%] Building C object
-- liblinear/CMakeFiles/liblinear.dir/liblinear_train.c.o
[ 61%] Building C object
-- liblinear/CMakeFiles/liblinear.dir/liblinear_predict.c.o
[ 66%] Building CXX object
-- liblinear/CMakeFiles/liblinear.dir/liblinear/linear.cpp.o
[ 72%] Building CXX object
-- liblinear/CMakeFiles/liblinear.dir/liblinear/tron.cpp.o
Linking CXX shared module libliblinear.so
[ 72%] Built target liblinear
Scanning dependencies of target libsvm
[ 77%] Building C object
-- libsvm/CMakeFiles/libsvm.dir/svm_model_torch.c.o
[ 83%] Building C object libsvm/CMakeFiles/libsvm.dir/init.c.o
[ 88%] Building C object libsvm/CMakeFiles/libsvm.dir/libsvm_train.c.o
[ 94%] Building C object libsvm/CMakeFiles/libsvm.dir/libsvm_predict.c.o
[100%] Building CXX object libsvm/CMakeFiles/libsvm.dir/libsvm/svm.cpp.o
Linking CXX shared module liblibsvm.so
[100%] Built target libsvm
cd build && make install
[ 16%] Built target svmutil
[ 38%] Built target liblinearblas
[ 72%] Built target liblinear
[100%] Built target libsvm
Install the project...
-- Install configuration: "Release"
-- Installing:
-- /usr/local/lib/luarocks/rocks/svm/0.1-0/lib/libsvmutil.dylib
-- Installing: /usr/local/lib/luarocks/rocks/svm/0.1-0/lua/svm/init.lua
-- Installing: /usr/local/lib/luarocks/rocks/svm/0.1-0/lua/svm/data.lua
-- Installing:
-- /usr/local/lib/luarocks/rocks/svm/0.1-0/lua/svmsgd/init.lua
-- Installing:
-- /usr/local/lib/luarocks/rocks/svm/0.1-0/lua/svmsgd/sgd.lua
-- Installing:
-- /usr/local/lib/luarocks/rocks/svm/0.1-0/lua/svmsgd/asgd.lua
-- Installing:
-- /usr/local/lib/luarocks/rocks/svm/0.1-0/lua/svmsgd/loss.lua
-- Installing:
-- /usr/local/lib/luarocks/rocks/svm/0.1-0/lib/libliblinear.so
-- Installing:
-- /usr/local/lib/luarocks/rocks/svm/0.1-0/lua/liblinear/init.lua
-- Installing: /usr/local/lib/luarocks/rocks/svm/0.1-0/lib/liblibsvm.so
-- Installing:
-- /usr/local/lib/luarocks/rocks/svm/0.1-0/lua/libsvm/init.lua
Warning: Directory 'doc' not found
Updating manifest for /usr/local/lib/luarocks/rocks

svm 0.1-0 is now built and installed in /usr/local/ (license: BSD)
```

Reviewers:

CC:
